### PR TITLE
Copy `previews` directory when bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Prefix your message with one of the following:
 - [Security] in case of vulnerabilities.
 -->
 
+## Unreleased
+
+- [Added] Support for including `previews` images in the bundled plugin
+
 ## v0.1.0-alpha.5
 
 - [Fixed] Fix Windows symlinking.

--- a/src/cli/bundle.ts
+++ b/src/cli/bundle.ts
@@ -279,7 +279,7 @@ async function compile(distDir: string, params: Params) {
     );
   });
 
-  const filesToCopy = glob.sync(`${sourceDir}/{images,css}/**/*.*`);
+  const filesToCopy = glob.sync(`${sourceDir}/{images,css,previews}/**/*.*`);
 
   filesToCopy.sort();
 


### PR DESCRIPTION
<!--
If you're making a doc PR or something tiny where the below is irrelevant,
delete this template and use a short description, but in your description aim to
include both what the change is, and why it is being made, with enough context
for anyone to understand.
-->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller
      PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into
      two PRs otherwise).
- [x] This PR's title starts is concise and descriptive.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or
      fixes.
- [ ] I've updated any docs, `.md` files, etc… affected by this change.

</details>

### What

If a `previews` directory is included in `src`, then it is copied to the final bundle.

### Why

Elgato requests that [at least 1 preview image](https://developer.elgato.com/documentation/stream-deck/sdk/distribution/#store-requirements) is included when submitting a plugin to the store.

### Known limitations
N/A
